### PR TITLE
fix: fixes the inability to synthesize because carrierGatewayId and d…

### DIFF
--- a/src/route-table.ts
+++ b/src/route-table.ts
@@ -86,9 +86,9 @@ export interface RouteTableRoute {
 function routeTableRouteToTerraform(struct?: RouteTableRoute): any {
   if (!cdktf.canInspect(struct)) { return struct; }
   return {
-    carrier_gateway_id: cdktf.stringToTerraform(struct!.carrierGatewayId),
+    carrier_gateway_id: struct!.carrierGatewayId === undefined ? null : cdktf.stringToTerraform(struct!.carrierGatewayId),
     cidr_block: struct!.cidrBlock === undefined ? null : cdktf.stringToTerraform(struct!.cidrBlock),
-    destination_prefix_list_id: cdktf.stringToTerraform(struct!.destinationPrefixListId),
+    destination_prefix_list_id: struct!.destinationPrefixListId === undefined ? null : cdktf.stringToTerraform(struct!.destinationPrefixListId),
     egress_only_gateway_id: struct!.egressOnlyGatewayId === undefined ? null : cdktf.stringToTerraform(struct!.egressOnlyGatewayId),
     gateway_id: struct!.gatewayId === undefined ? null : cdktf.stringToTerraform(struct!.gatewayId),
     instance_id: struct!.instanceId === undefined ? null : cdktf.stringToTerraform(struct!.instanceId),


### PR DESCRIPTION
…estinationPrevixListId are always required.  Currently RouteTable is unuseable

Currently you can't make a RouteTable since all routes require both a carrierGatewayId and a destinationPrefixListId. For some reason these 2 values never got an undefined check added so they never pass null but instead make a call to cdktf.stringToTerraform.  I'm guessing this has never been caught as everyone is using the vpc module shown in the demos. If you try to roll your own pure Typescript VPC you'll run into this pretty quickly.
Fixes #